### PR TITLE
Fix issue where platform can return no devices

### DIFF
--- a/worker/opencl_info.go
+++ b/worker/opencl_info.go
@@ -20,6 +20,9 @@ func GetAvailableDevices() (shared.DeviceMap, error) {
 	for _, platform := range platforms {
 		devices, err := platform.GetDevices(opencl.DeviceTypeAll)
 		if err != nil {
+			if err == opencl.ErrDeviceNotFound {
+				continue
+			}
 			return nil, err
 		}
 
@@ -37,6 +40,10 @@ func GetAvailableDevices() (shared.DeviceMap, error) {
 			}
 			devs[gDeviceID] = dev
 		}
+	}
+
+	if len(devs) == 0 {
+		return nil, opencl.ErrDeviceNotFound
 	}
 
 	return devs, nil


### PR DESCRIPTION
OpenCL platforms can exist without any devices, continue to next platform instead of erroring